### PR TITLE
Security updates for 10.0.x release branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,9 @@ ARG skip_dev_deps
 
 RUN useradd --create-home redash
 
-RUN apt update -y && apt upgrade -y && apt autoremove -y
 
 # Ubuntu packages
-RUN apt-get update && \
+RUN apt-get update && apt-get upgrade -y && apt-get autoremove -y && \
   apt-get install -y \
     curl \
     gnupg \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12 as frontend-builder
+FROM node:14.17-bullseye as frontend-builder
 
 # Controls whether to build the frontend assets
 ARG skip_frontend_build
@@ -23,7 +23,7 @@ COPY --chown=redash client /frontend/client
 COPY --chown=redash webpack.config.js /frontend/
 RUN if [ "x$skip_frontend_build" = "x" ] ; then npm run build; else mkdir -p /frontend/client/dist && touch /frontend/client/dist/multi_org.html && touch /frontend/client/dist/index.html; fi
 
-FROM python:3.7-slim-buster
+FROM python:3.7.13-slim-bullseye
 
 EXPOSE 5000
 
@@ -33,6 +33,8 @@ ARG skip_ds_deps
 ARG skip_dev_deps
 
 RUN useradd --create-home redash
+
+RUN apt update -y && apt upgrade -y && apt autoremove -y
 
 # Ubuntu packages
 RUN apt-get update && \
@@ -49,6 +51,7 @@ RUN apt-get update && \
     libpq-dev \
     # ODBC support:
     g++ unixodbc-dev \
+    unixodbc \
     # for SAML
     xmlsec1 \
     # Additional packages required for data sources:


### PR DESCRIPTION
Added changes suggested by PhilipJohnson: https://gist.github.com/phillipjohnson/290412e8c4291dcd23e320c981f96867

To create the image `redash/redash` with version `10.1.1`:
```bash
$ docker build -t redash/redash:10.1.1 .
```
Then running `grype` on this gives these [results](https://github.com/diffblue/redash/files/9657744/grype-10.1.1.txt)

[grype-10.1.1-only-fixed.txt](https://github.com/diffblue/redash/files/9657841/grype-10.1.1-only-fixed.txt)


## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
