### PR TITLE
Upgrade Vulnerable Python Dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY --chown=redash client /frontend/client
 COPY --chown=redash webpack.config.js /frontend/
 RUN if [ "x$skip_frontend_build" = "x" ] ; then npm run build; else mkdir -p /frontend/client/dist && touch /frontend/client/dist/multi_org.html && touch /frontend/client/dist/index.html; fi
 
-FROM python:3.7.13-slim-bullseye
+FROM --platform=amd64 python:3.7.13-slim-bullseye
 
 EXPOSE 5000
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ blinker==1.4
 psycopg2==2.8.3
 python-dateutil==2.8.0
 pytz>=2019.3
-PyYAML==5.1.2
+PyYAML==5.4
 redis==3.5.0
 requests==2.21.0
 SQLAlchemy==1.3.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ xlsxwriter==1.2.2
 pystache==0.5.4
 parsedatetime==2.4
 PyJWT==1.7.1
-cryptography==2.8
+cryptography==3.3.2
 simplejson==3.16.0
 ua-parser==0.8.0
 user-agents==2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,10 @@
+## This is required because pystache==0.5.4 errors with:
+#   Complete output (3 lines):
+#   pystache: using: version '60.2.0' of <module 'setuptools' from '.../venv/lib/python3.7/site-packages/setuptools/__init__.py'>
+#   Warning: 'classifiers' should be a list, got type 'tuple'
+#   error in pystache setup command: use_2to3 is invalid.
+setuptools==50.3.2
+
 Flask==1.1.1
 Jinja2==2.10.3
 itsdangerous==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,6 @@ rq-scheduler==0.9.1
 jsonschema==3.1.1
 RestrictedPython==5.0
 pysaml2==6.1.0
-pycrypto==2.6.1
 python-dotenv==0.19.2
 funcy==1.13
 sentry-sdk>=0.14.3,<0.15.0


### PR DESCRIPTION
## What type of PR is this? 
- [x] Bug Fix
- [x] Other

## Description

This PR updates _critical_ vulnerabilities found when scanning the redash image using [grype](https://github.com/anchore/grype). The commit messages explain some detail as to what's happening in each of the version bumps (and I've done it this way to make it easy to select which dependencies are updated).

CVE-2013-7459, CVE-2020-36242, CVE-2020-1747, CVE-2019-20477, CVE-2020-14343

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] Manually

I've run the unit tests and the `reencrypt` command and didn't see any errors.

## Related Tickets & Documents