### PR TITLE
Adjusts the github action workflow to use the metadata action

### DIFF
--- a/.github/workflows/build-and-publish-docker-image.yml
+++ b/.github/workflows/build-and-publish-docker-image.yml
@@ -1,7 +1,6 @@
 name: Docker Image CI
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - 'release/10.0.x'
@@ -12,23 +11,33 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
-
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a
+        with:
+          images: |
+            diffblue/redash
+          flavor: |
+            latest=false
+            suffix=.{{sha}},onlatest=false
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
+            type=raw,value=10.1.1,enable=${{ github.ref == format('refs/heads/release/{0}', '10.0.x') }}
+            type=raw,event=pr,value=dev
       - name: Log in to Docker Hub
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: diffblue/redash
-
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
           push: true
-          tags: 10.1.1.${{ github.event.pull_request.head.sha }}
           labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This adjusts the github action workflow to use the [github metadata action](https://github.com/docker/metadata-action). This allows more sophisticated configuration of image tags.

Specifically:

* the `latest` tag is used for master branch builds
* the `10.1.1` tag, with a suffix of the git SHA, is used for builds from branch `release/10.0.x`
* the `dev` tag, with a suffix of the git SHA, is used for builds from a PR. This is a default position that is useful for testing the workflow. Normally, however, this workflow should only be triggered on pushes to `release/10.0.x` or master, so this will not get used.
  
## What type of PR is this? 

- [X] Other

## How is this tested?

- [X] N/A