### PR TITLE
Force use of importlib metadata version less than 5

### DIFF
--- a/requirements_bundles.txt
+++ b/requirements_bundles.txt
@@ -4,5 +4,5 @@
 # It's automatically installed when running npm run bundle
 
 # These can be removed when upgrading to Python 3.x
-importlib-metadata>=1.6  # remove when on 3.8
+importlib-metadata>=1.6,<5.0.0  # remove when on 3.8
 importlib_resources==1.5  # remove when on 3.9


### PR DESCRIPTION
Prevent use of `importlib-metadata` version greater than or equal to 5.0.0 since this removes compatibility shims for deprecated entry point interfaces.

https://importlib-metadata.readthedocs.io/en/latest/history.html

- [X] Other

