### PR TITLE
Update python libraries to remove high security vulnerabilities identified by grype

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ itsdangerous==1.1.0
 click==6.7
 MarkupSafe==1.1.1
 pyOpenSSL==19.0.0
-httplib2==0.14.0
+httplib2==0.19.0
 wtforms==2.2.1
 Flask-RESTful==0.3.7
 Flask-Login==0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ semver==2.8.1
 xlsxwriter==1.2.2
 pystache==0.5.4
 parsedatetime==2.4
-PyJWT==1.7.1
+PyJWT==2.4.0
 cryptography==3.3.2
 simplejson==3.16.0
 ua-parser==0.8.0

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -22,7 +22,7 @@ memsql==3.0.0
 atsd_client==3.0.5
 simple_salesforce==0.74.3
 PyAthena>=1.5.0
-pymapd==0.19.0
+pymapd==0.26.0
 qds-sdk>=1.9.6
 ibm-db>=2.0.9
 pydruid==0.5.7


### PR DESCRIPTION
This upgrades several python libraries to remove known high vulnerabilities.

The test suite was run with no failures.

Libraries affected:
* httplib2 -> 0.19.0 (CVE-2020-11078)
* PyJWT -> 2.4.0 (CVE-2022-29217)
* pymapd -> 0.26.0 (this removes  vulnerability in pyarrow CVE-2019-12410)





