### PR TITLE
Bump version of jinja

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 setuptools==50.3.2
 
 Flask==1.1.1
-Jinja2==2.10.3
+Jinja2==2.11.3
 itsdangerous==1.1.0
 click==6.7
 MarkupSafe==1.1.1


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Other

## Description
Bumps the version of jinja2 to avoid GHSA-g3rq-g295-4j3m