### PR TITLE
Upgraded pysaml2 to version 7.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ rq==1.5.0
 rq-scheduler==0.9.1
 jsonschema==3.1.1
 RestrictedPython==5.0
-pysaml2==6.1.0
+pysaml2==7.2.1
 python-dotenv==0.19.2
 funcy==1.13
 sentry-sdk>=0.14.3,<0.15.0


### PR DESCRIPTION
Upgrade pysaml to latest to resolve vulnerability: GHSA-5p3x-r448-pc62 and GHSA-f4g9-h89h-jgv9

- [X] Other

Tests pass locally.
