### PR TITLE
Upgraded to python 3.8.14-slim-bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY --chown=redash client /frontend/client
 COPY --chown=redash webpack.config.js /frontend/
 RUN if [ "x$skip_frontend_build" = "x" ] ; then npm run build; else mkdir -p /frontend/client/dist && touch /frontend/client/dist/multi_org.html && touch /frontend/client/dist/index.html; fi
 
-FROM --platform=amd64 python:3.7.13-slim-bullseye
+FROM --platform=amd64 python:3.8.14-slim-bullseye
 
 EXPOSE 5000
 
@@ -59,7 +59,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get autoremove -y && \
     libsasl2-dev \
     unzip \
     libsasl2-modules-gssapi-mit && \
-  # MSSQL ODBC Driver:  
+  # MSSQL ODBC Driver:
   curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
   curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
   apt-get update && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ pyparsing==2.4.2
 SQLAlchemy-Utils==0.34.2
 sqlparse==0.3.0
 statsd==3.3.0
-greenlet==0.4.16
+greenlet>=0.4.16
 gunicorn==20.0.4
 rq==1.5.0
 rq-scheduler==0.9.1
@@ -60,7 +60,7 @@ user-agents==2.0
 maxminddb-geolite2==2018.703
 pypd==1.1.0
 disposable-email-domains>=0.0.52
-gevent==1.4.0
+gevent>=1.4.0
 sshtunnel==0.1.5
 supervisor==4.1.0
 supervisor_checks==0.8.1

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -8,7 +8,7 @@ pyhive==0.6.1
 pymongo[tls,srv]==3.9.0
 vertica-python==0.9.5
 td-client==1.0.0
-pymssql==2.1.4
+pymssql>=2.1.4
 dql==0.6.0
 dynamo3==1.0.0
 boto3==1.24.85


### PR DESCRIPTION
This upgrade was required to allow an upgrade of `numpy` from 1.21.6 to fix vulnerability GHSA-fpfv-jqm9-f5jm.

To allow this other libs were also upgraded:

* greenlet
* gevent
* pymssql

- [X] Other

All tests passed locally.
