### PR TITLE
Ensure gunicorn can be found in the path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -129,5 +129,12 @@ LABEL summary="$SUMMARY" \
       maintainer="$MAINTAINER" \
       org.opencontainers.image.authors="$MAINTAINER"
 
+# There are three paths we need to prepend to the PATH.
+# `/opt/app-root/bin` and `/opt/app-root/src/.local/bin/` are for redhat/ubi, while `/home/redash/.local/bin/` is for
+# debian. These are needed to point to `gunicorn` (which runs the server for the flask app and thus redash). With out
+# these there is no server and the container will not start. Ideally, they'd be specified in each of the containers
+# and we'd not cross polinate, however, when we create the underlying images we've not yet installed pip, let alone
+# gunicorn.
+ENV PATH=/home/redash/.local/bin/:/opt/app-root/bin:/opt/app-root/src/.local/bin/:${PATH}
 ENTRYPOINT ["/app/bin/docker-entrypoint"]
 CMD ["server"]

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -32,7 +32,7 @@ server() {
   # Recycle gunicorn workers every n-th request. See http://docs.gunicorn.org/en/stable/settings.html#max-requests for more details.
   MAX_REQUESTS=${MAX_REQUESTS:-1000}
   MAX_REQUESTS_JITTER=${MAX_REQUESTS_JITTER:-100}
-  exec /opt/app-root/bin/gunicorn -b 0.0.0.0:5000 --name redash -w${REDASH_WEB_WORKERS:-4} redash.wsgi:app --max-requests $MAX_REQUESTS --max-requests-jitter $MAX_REQUESTS_JITTER
+  exec gunicorn -b 0.0.0.0:5000 --name redash -w${REDASH_WEB_WORKERS:-4} redash.wsgi:app --max-requests $MAX_REQUESTS --max-requests-jitter $MAX_REQUESTS_JITTER
 }
 
 create_db() {


### PR DESCRIPTION
The paths being prepended are from both the debian and redhat/ubi -- ideally they'd be contained in their separate image layers, but at that point gunicorn hasn't been installed.
