### PR TITLE
Fix safari `history.replaceState` bug

### DIFF
--- a/client/app/components/Parameters.jsx
+++ b/client/app/components/Parameters.jsx
@@ -1,4 +1,4 @@
-import { size, filter, forEach, extend } from "lodash";
+import { size, filter, forEach, extend, isEqual } from "lodash";
 import React from "react";
 import PropTypes from "prop-types";
 import { SortableContainer, SortableElement, DragHandle } from "@redash/viz/lib/components/sortable";
@@ -54,7 +54,7 @@ export default class Parameters extends React.Component {
 
   componentDidUpdate = prevProps => {
     const { parameters, disableUrlUpdate } = this.props;
-    const parametersChanged = prevProps.parameters !== parameters;
+    const parametersChanged = !isEqual(prevProps.parameters, parameters);
     const disableUrlUpdateChanged = prevProps.disableUrlUpdate !== disableUrlUpdate;
     if (parametersChanged) {
       this.setState({ parameters });


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [x] Bug Fix

## Description

A bug occurs when loading redash in safari where it will error out complaining: 

> SecurityError: Attempt to use history.replaceState() more than 100 times per 30 seconds

Refreshing can fix this issue, however, since over 40 invocations of `history.replaceState()` seem to occur every time we navigate in reports, this error will be seen any time a user clicks only 3 links within a 30 second window.

This fix is suggested by https://github.com/getredash/redash/pull/5586, where it seems that the comparison method for `parametersChanged` is not deep equals, so it always evaluates to true.

### Calling `history.replace()` only 'when required'

One suggestion to fix this is to only call the history replace state code when we need to. (I.e taking the assumption that redash calls to change history more than is necessary). From my look into this so far, this doesn't seem like a feasible solution. This is because each call to update the state adds a different part of the location (i.e the contructor of `parameters.jsx` seems to add the parameters, the `RefreshRateHandler` adds the refresh interval, `FullscreenHandler` adds whether redash should be fullscreen, etc.). The primary reason the we have so many calls, even with this fix, is that we have 4 iframes all loading new content at the same time in different tabs.

### Issue with multiple query parameters

The issue described (and shown) as a part of [the initial PR for this fix](https://github.com/getredash/redash/pull/5586#pullrequestreview-838752534) is still relevant for us. However, this seems to be quite a minor issue, and has no bearing on what our customers will see, only a slightly more inconvenient for developers making a query with multiple parameters in a dropdown list.

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

I ran cover with the built redash image (see #3 for instructions, just replacing `redash/redash:10.1.1` with `diffblue/redash:10.1.1-ubi.5981246`, taken from covers' `docker-compose.yml`)

I logged the cases of instances where `history.replaceState()`would be called. After this PR, the invocations of replacing history state in `Parameters.jsx` by `componentDidUpdate` change from >40 to 0.

Despite this change, there are still 18 invocations of replacing history state each time we select a new node.  This means that the error will show up once a user clicks on 6 links within a 30 second window.

This is largely down to the fact that safari doesn't properly support lazy loading iframes, so all 4 of our iframes often get loaded at once. Chrome, for comparison, has only 4/5 invocations. In order to deal with this, we will need to modify our code to lazy load the tabs instead, to sidestep safari's inadequate iframe lazy loading.
